### PR TITLE
Fix github CI by upgrading pip

### DIFF
--- a/.github/workflows/test-readme.yml
+++ b/.github/workflows/test-readme.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
       - name: Install depedencies
         run: pip install -e '.[dev]'
       - name: Run tests


### PR DESCRIPTION
Old version apparently had some problems with `-e` and/or pyproject.toml